### PR TITLE
[Bug] Fix Missing Closing Brace in nav CSS Block

### DIFF
--- a/style.css
+++ b/style.css
@@ -248,6 +248,7 @@ nav {
 
 .mobile-menu.active {
   left: 0;
+}
 nav a,
 nav .dropdown-content a {
   color: #fff;


### PR DESCRIPTION
Fixed a missing closing brace `}` in the `nav` CSS block which was causing layout and rendering issues across pages. This bug could break the stylesheet rendering for all navigation-related styles, especially affecting responsiveness and alignment.

Fixes #110
