### PR TITLE
fix: changed the color of ~ What Makes Us Different

### DIFF
--- a/assets/css_files/aboutus.css
+++ b/assets/css_files/aboutus.css
@@ -267,9 +267,22 @@ background: linear-gradient(135deg, #667eea, #764ba2);
 .features-section {
   margin: 4rem 0;
 }
+.section-title-2{
+  font-family: 'Inter', sans-serif;
+  font-size: 2.5rem;
+  font-weight: 800; 
+  background: linear-gradient(to right, #667eea, #764ba2);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text; 
+  color: transparent;
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1); 
+  margin-bottom: 3rem; 
+  
+}
 
-.features-grid {
-  display: grid;
+.features-grid { 
+  display: grid; 
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 2rem;
 }

--- a/assets/html_files/aboutus.html
+++ b/assets/html_files/aboutus.html
@@ -189,7 +189,7 @@
         </div>
 
         <div class="features-section">
-          <h2 class="section-title">What Makes Us Different</h2>
+          <h2 class="section-title-2">What Makes Us Different</h2>
           <div class="features-grid">
             <div class="feature-item">
               <div class="feature-icon">


### PR DESCRIPTION
## 📥 Pull Request

### Description
I fixed the color of "What Makes Us Different" section & now it's readable properly.

Fixes #227 

### Type of change: Bug fixing

### Solution Description: 

- Named the class ".section-title-2" under ".features-section" in aboutus.html file.
- Styled  ".section-title-2" , under aboutus.css file with proper layouts & colors using CSS.

## Demo Video(Mandatory):
video 

[screen-capture.webm](https://github.com/user-attachments/assets/78efc76b-7468-4822-b7de-7d01edea40c9)

