### PR TITLE
Enhance: Unified footer styling across About and FAQ pages

### DIFF
--- a/assets/css_files/aboutus.css
+++ b/assets/css_files/aboutus.css
@@ -590,3 +590,53 @@ background: linear-gradient(135deg, #667eea, #764ba2);
     transform: translateY(0);
   }
 }
+/* footer-css */
+.site-footer {
+    background-color: #222;
+    color: #ddd;
+    padding: 40px 20px 20px;
+    font-family: 'Nunito Sans', sans-serif;
+}
+
+.footer-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 30px;
+    max-width: 1200px;
+    margin: auto;
+}
+
+.footer-container h3 {
+    color: #fff;
+    margin-bottom: 15px;
+}
+
+.footer-container p,
+.footer-container a {
+    font-size: 14px;
+    color: #bbb;
+    text-decoration: none;
+}
+
+.footer-container a:hover {
+    color: #fff;
+}
+
+.footer-links ul {
+    list-style: none;
+    padding: 0;
+}
+
+.footer-links ul li {
+    margin-bottom: 8px;
+}
+
+.footer-bottom {
+    text-align: center;
+    border-top: 1px solid #444;
+    padding-top: 15px;
+    margin-top: 30px;
+    font-size: 13px;
+    color: #aaa;
+}

--- a/assets/html_files/aboutus.html
+++ b/assets/html_files/aboutus.html
@@ -257,7 +257,7 @@
       </div>
     </main>
 
-    <footer id="contact">
+    <footer>
       <div class="footer-container">
         <div class="footer-section company-info">
           <h1 class="heading">Project Vault</h1>
@@ -295,30 +295,6 @@
             </a>
           </div>
         </div>
-
-            <div class="footer-section quick-links">
-                <h1 class="heading">Quick Links</h1>
-                <ul class="footer-ul">
-                    <li>
-                        <a href="../../index.html"><i class="fa-solid fa-house"></i> Home</a>
-                    </li>
-                    <li>
-                        <a href="./aboutus.html"><i class="fa-solid fa-circle-info"></i> About</a>
-                    </li>
-                    <li>
-                        <a href="#"><i class="fa-solid fa-icons"></i> Components</a>
-                    </li>
-                    <li>
-                        <a href="../../faq.html"><i class="fa-solid fa-question-circle"></i> FAQ</a>
-                    </li>
-                    <li>
-                        <a href="./discussion.html"><i class="fa-solid fa-comment"></i> Forum</a>
-                    </li>
-                    <li>
-                        <a href="./contact.html"><i class="fa-solid fa-phone"></i> Contact</a>
-                    </li>
-                </ul>
-            </div>
 
         <div class="footer-section quick-links">
           <h1 class="heading">Quick Links</h1>

--- a/faq.css
+++ b/faq.css
@@ -212,22 +212,52 @@ h1 {
 
 /* footer-css */
 
-.footer {
-  width: 100vw;
-  height: 10rem;
+.site-footer {
+    background-color: #222;
+    color: #ddd;
+    padding: 40px 20px 20px;
+    font-family: 'Nunito Sans', sans-serif;
+}
 
+.footer-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 30px;
+    max-width: 1200px;
+    margin: auto;
 }
-.footer-section{
-  border: 3px solid;
+
+.footer-container h3 {
+    color: #fff;
+    margin-bottom: 15px;
 }
-.company-info {
-  margin: 50px 60px ;
-  text-align: center;
-  max-width: 100%;
-  border: 3px solid;
+
+.footer-container p,
+.footer-container a {
+    font-size: 14px;
+    color: #bbb;
+    text-decoration: none;
 }
-.company-info .heading{
-  color: black;
-  font-size: 1.3rem;
-  line-height: 1.6;
+
+.footer-container a:hover {
+    color: #fff;
+}
+
+.footer-links ul {
+    list-style: none;
+    padding: 0;
+}
+
+.footer-links ul li {
+    margin-bottom: 8px;
+}
+
+.footer-bottom {
+    text-align: center;
+    border-top: 1px solid #444;
+    padding-top: 15px;
+    margin-top: 30px;
+    font-size: 13px;
+    color: #aaa;
 }


### PR DESCRIPTION
Description
This pull request improves UI consistency by fixing the visible border styles in the footer sections of both the FAQ and About Us pages. 

Fixes and Enhancements:
Removed visible borders that were appearing before the content blocks (Project Vault, Quick Links, Contact Form) on the FAQ page.
- Ensured consistent footer appearance across all pages by removing unnecessary 3px solid #ddd borders no border for a cleaner look.
- Removed duplicate "Quick Links" section that was present twice in the About us page footer.

issue: #288 
Result:

**AboutUs Page:**

<img width="1809" height="1019" alt="Screenshot 2025-08-03 132331" src="https://github.com/user-attachments/assets/7910d8ab-17d3-48af-8c91-23e47441aa7c" />

**FAQ Page:**

<img width="1816" height="1036" alt="Screenshot 2025-08-03 132344" src="https://github.com/user-attachments/assets/60f388f3-4998-40bf-baa9-ae45be91b91d" />
